### PR TITLE
update to reagent 0.8.1 and following new

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Add this to your `project.clj`:
 To create an interval:
 
 ```
-(require '[re-interval.core :refer [register-interval-handlers]])
-(register-interval-handlers :interval-prefix middleware timeout-in-ms)
+(require '[re-interval.core :refer [reg-event-interval]])
+(reg-event-interval :interval-prefix middleware timeout-in-ms)
 ```
 
 To activate the interval, dispatch the event `:interval-prefix/start`. When

--- a/project.clj
+++ b/project.clj
@@ -1,15 +1,26 @@
-(defproject re-interval "0.0.1"
+(defproject re-interval "0.1.0"
+
   :description "A re-frame/ClojureScript library for creating intervals controlled by events."
+
   :url "https://github.com/caioaao/re-interval"
+
   :license {:name "MIT"}
+
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.8.51"]
-                 [org.clojure/core.async "0.2.374"]
-                 [re-frame "0.7.0"]]
+                 [org.clojure/clojurescript "1.10.339"]
+                 [org.clojure/core.async "0.4.474"]
+                 [re-frame "0.8.1"]]
+
   :jvm-opts ^:replace ["-Xmx1g" "-server"]
+
   :plugins [[lein-npm "0.6.1"]]
+
   :npm {:dependencies [[source-map-support "0.4.0"]]}
+
   :source-paths ["src" "target/classes"]
+
   :clean-targets ["out" "release"]
+
   :target-path "target"
+
   :profiles {:dev {:plugins [[com.cemerick/austin "0.1.6"]]}})


### PR DESCRIPTION
syntax. register-interval-handlers renamed to reg-event-interval to
follow reagent's naming scheme more closely